### PR TITLE
Use class template and semaphore for shared memory

### DIFF
--- a/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.cpp
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.cpp
@@ -1,61 +1,9 @@
 #include "SharedMem.h"
 
-SharedMem::SharedMem(bool OpenCreate) 
-{
-	InitMemory(OpenCreate);
-}
+SharedMemDataJoystick* g_pSharedData = NULL;
+SharedMem<SharedMemDataJoystick> g_SharedMem(SHARED_MEM_NAME, true, true);
 
-bool SharedMem::InitMemory(bool OpenCreate) 
-{
-	pSharedMemPtr = NULL;
-
-	if (OpenCreate) {
-		hMapFile = CreateFileMapping(
-			INVALID_HANDLE_VALUE,    // use paging file
-			NULL,                    // default security
-			PAGE_READWRITE,          // read/write access
-			0,                       // maximum object size (high-order DWORD)
-			SHARED_MEM_SIZE,         // maximum object size (low-order DWORD)
-			SHARED_MEM_NAME);        // name of mapping object
-
-		if (hMapFile == NULL)
-		{
-			return false;
-		}
-	}
-	else {
-		hMapFile = OpenFileMapping(
-			FILE_MAP_ALL_ACCESS,   // read/write access
-			FALSE,                 // do not inherit the name
-			SHARED_MEM_NAME);      // name of mapping object
-
-		if (hMapFile == NULL)
-		{
-			return false;
-		}
-	}
-
-	pSharedMemPtr = (LPTSTR)MapViewOfFile(hMapFile,   // handle to map object
-		FILE_MAP_ALL_ACCESS, // read/write permission
-		0,
-		0,
-		SHARED_MEM_SIZE);
-
-	if (pSharedMemPtr == NULL) {
-		return false;
-	}
-
-	return true;
-}
-
-SharedMem::~SharedMem()
-{
-	UnmapViewOfFile(pSharedMemPtr);
-
-	CloseHandle(hMapFile);
-}
-
-void *SharedMem::GetMemoryPtr()
-{
-	return pSharedMemPtr;
+void InitSharedMem() {
+	g_pSharedData = g_SharedMem.GetMemoryPointer();
+	g_SharedMem.SetDataReady();
 }

--- a/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.h
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.h
@@ -1,52 +1,22 @@
 #pragma once
 
 #include <windows.h>
+#include "SharedMemTemplate.h"
 
-// This is the actual data that will be shared across DLLs. It contains
-// a mixture of custom fields and a generic pointer to share whatever else
-// we need later.
-struct SharedData {
-	// Offset added to the current POV when VR is active. This is controlled by ddraw
-	float POVOffsetX, POVOffsetY, POVOffsetZ;
-	void *pDataPtr;
-	// Euler angles, in degrees, for the current camera matrix coming from SteamVR. This is
-	// written by CockpitLookHook:
-	float Yaw, Pitch, Roll;
-	// Positional tracking data. Written by CockpitLookHook:
-	float X, Y, Z;
+struct SharedMemDataJoystick {
 	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
 	// These values are normalized in the range -1..1
 	float JoystickYaw, JoystickPitch;
-	// Flag that indicates the reticle needs setup.
-	int bIsReticleSetup;
+
+	SharedMemDataJoystick() {
+		JoystickYaw = 0.0f;
+		JoystickPitch = 0.0f;
+	}
 };
 
-// This is a proxy to share data between the hook and ddraw.
-// This proxy should only contain two fields:
-// - bDataReady is set to true once the writer has initialized
-//   the proxy structure.
-// - pDataPtr points to the actual data to be shared in the regular
-//   heap space
-struct SharedDataProxy {
-	bool bDataReady;
-	SharedData *pSharedData;
-};
+void InitSharedMem();
 
-constexpr auto SHARED_MEM_NAME = "Local\\CockpitLookHook";
-constexpr auto SHARED_MEM_SIZE = sizeof(SharedDataProxy);
+const auto SHARED_MEM_NAME = L"Local\\JoystickFfHook";
 
-// This is the shared memory handler. Call GetMemoryPtr to get a pointer
-// to a SharedData structure
-class SharedMem {
-private:
-	HANDLE hMapFile;
-	void *pSharedMemPtr;
-	bool InitMemory(bool OpenCreate);
-
-public:
-	// Specify true in OpenCreate to create the shared memory handle. Set it to false to
-	// open an existing shared memory handle.
-	SharedMem(bool OpenCreate);
-	~SharedMem();
-	void *GetMemoryPtr();
-};
+extern SharedMemDataJoystick* g_pSharedData;
+extern SharedMem<SharedMemDataJoystick> g_SharedMem;

--- a/xwa_hook_joystick_ff/hook_joystick_ff/SharedMemTemplate.h
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/SharedMemTemplate.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <string>
+
+template<class T>
+class SharedMem
+{
+public:
+	SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate);
+	~SharedMem();
+
+	T* GetMemoryPointer();
+	bool IsDataReady();
+	void SetDataReady();
+
+private:
+	HANDLE hMapFile;
+	HANDLE hSemaphore;
+	T* pSharedData;
+};
+
+template<class T>
+SharedMem<T>::SharedMem(LPCWSTR name, bool createIfNotExists, bool availableOnCreate)
+{
+	pSharedData = nullptr;
+	hSemaphore = NULL;
+
+	if (createIfNotExists)
+	{
+		hMapFile = CreateFileMappingW(
+			INVALID_HANDLE_VALUE,    // use paging file
+			NULL,                    // default security
+			PAGE_READWRITE,          // read/write access
+			0,                       // maximum object size (high-order DWORD)
+			sizeof(T),         // maximum object size (low-order DWORD)
+			name);        // name of mapping object
+	}
+	else
+	{
+		hMapFile = OpenFileMappingW(
+			FILE_MAP_ALL_ACCESS,   // read/write access
+			FALSE,                 // do not inherit the name
+			name);      // name of mapping object
+	}
+
+	if (!hMapFile)
+	{
+		return;
+	}
+
+	pSharedData = (T*)MapViewOfFile(
+		hMapFile,   // handle to map object
+		FILE_MAP_ALL_ACCESS, // read/write permission
+		0,
+		0,
+		sizeof(T));
+
+	LONG initialCount = availableOnCreate ? 1 : 0;
+	initialCount = 1;
+	std::wstring semaphoreName = name;
+	semaphoreName.append(L"Semaphore");
+	hSemaphore = CreateSemaphoreW(
+		NULL,					// default security attributes
+		initialCount,			// initial count
+		1,						// maximum count
+		semaphoreName.c_str()	// semaphore name);
+	);
+}
+
+template<class T>
+SharedMem<T>::~SharedMem()
+{
+	UnmapViewOfFile(pSharedData);
+	CloseHandle(hMapFile);
+	CloseHandle(hSemaphore);
+}
+
+template<class T>
+T* SharedMem<T>::GetMemoryPointer()
+{
+	return pSharedData;
+}
+
+template<class T>
+bool SharedMem<T>::IsDataReady()
+{
+	if (hSemaphore == NULL) return false;
+	DWORD dwWaitResult;
+	dwWaitResult = WaitForSingleObject(hSemaphore, 0);
+	//log_debug("[DBG][SharedMem] IsDataReady::dwWaitResult = %d",  dwWaitResult);
+	switch (dwWaitResult) {
+		// The semaphore was signaled, the data is ready
+	case WAIT_OBJECT_0:
+		// We release it again immediately since we don't need exclusive or atomic access
+		// (there are no concurrent threads)
+		ReleaseSemaphore(hSemaphore, 1, NULL);
+		return true;
+		break;
+
+		// The semaphore was nonsignaled, so a time-out occurred.
+		// This should only happen when the data is not ready to be accessed
+		// (missing/disabled hook, not initialized or not generating data.
+	case WAIT_TIMEOUT:
+		return false;
+		break;
+	}
+	return false;
+}
+
+template<class T>
+void SharedMem<T>::SetDataReady()
+{
+	ReleaseSemaphore(hSemaphore, 1, NULL);
+}

--- a/xwa_hook_joystick_ff/hook_joystick_ff/hook_joystick_ff.vcxproj
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/hook_joystick_ff.vcxproj
@@ -98,6 +98,7 @@
     <ClInclude Include="joystick.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SharedMem.h" />
+    <ClInclude Include="SharedMemTemplate.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>

--- a/xwa_hook_joystick_ff/hook_joystick_ff/hook_joystick_ff.vcxproj.filters
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/hook_joystick_ff.vcxproj.filters
@@ -24,7 +24,7 @@
     <ClCompile Include="joystick.cpp">
       <Filter>Fichiers sources</Filter>
     </ClCompile>
-	<ClCompile Include="SharedMem.cpp">
+    <ClCompile Include="SharedMem.cpp">
       <Filter>Fichiers sources</Filter>
     </ClCompile>
   </ItemGroup>
@@ -44,10 +44,13 @@
     <ClInclude Include="resource.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
-	<ClInclude Include="SharedMem.h">
+    <ClInclude Include="SharedMem.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
     <ClInclude Include="targetver.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="SharedMemTemplate.h">
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
   </ItemGroup>

--- a/xwa_hook_joystick_ff/hook_joystick_ff/joystick.cpp
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/joystick.cpp
@@ -15,9 +15,6 @@ const auto& g_joyGetDevCapsA = *(decltype(joyGetDevCapsA)**)0x005A92A8;
 const auto& g_joyGetPosEx = *(decltype(joyGetPosEx)**)0x005A92A4;
 
 #include "SharedMem.h"
-SharedDataProxy *g_pSharedData = NULL;
-// ddraw is loaded after the hooks, so here we open an existing shared memory handle:
-SharedMem g_SharedMem(false);
 
 enum KeyEnum : unsigned short
 {
@@ -33,10 +30,6 @@ enum KeyEnum : unsigned short
 	Key_NUMPAD8 = 186,
 	Key_NUMPAD9 = 187,
 };
-
-void InitSharedMem() {
-	g_pSharedData = (SharedDataProxy *)g_SharedMem.GetMemoryPtr();
-}
 
 class Config
 {
@@ -1008,9 +1001,9 @@ int UpdateControllerHook(int* params)
 	}
 	float normYaw = 2.0f * (esp10.dwXpos / 65535.0f - 0.5f); // -1: Left, 1: Right
 	float normPitch = 2.0f * (esp10.dwYpos / 65535.0f - 0.5f); // -1: Up, 1: Down
-	if (g_pSharedData != NULL && g_pSharedData->bDataReady) {
-		g_pSharedData->pSharedData->JoystickYaw = normYaw;
-		g_pSharedData->pSharedData->JoystickPitch = normPitch;
+	if (g_pSharedData != NULL) {
+		g_pSharedData->JoystickYaw = normYaw;
+		g_pSharedData->JoystickPitch = normPitch;
 	}
 
 	return 0;


### PR DESCRIPTION
Use a class template to define the SharedMem manager class. This allows to re-use the same code for sharing data between different hooks using specific struct definitions but the same SharedMem manager.

Instead of storing just a pointer to the heap in shared memory, put the whole shared structure in the memory mapped file for simplicity.

To signal the availability of data from the hook, use a binary semaphore. This is optional, it's up to the consumer to use the IsDataReady() function.