### PR TITLE
Add code needed to make this hook compatible with the gimbal lock fix.

### DIFF
--- a/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.h
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/SharedMem.h
@@ -6,11 +6,22 @@
 struct SharedMemDataJoystick {
 	// Joystick's position, written by the joystick hook, or by the joystick emulation code.
 	// These values are normalized in the range -1..1
-	float JoystickYaw, JoystickPitch;
+	float JoystickYaw, JoystickPitch, JoystickRoll;
+	// If the gimbal lock fix is active, the following will disable the joystick (default: false)
+	// Set by ddraw
+	bool GimbalLockFixActive;
+	// Set by ddraw when joystick emulation is enabled
+	bool JoystickEmulationEnabled;
+	// Set by the joystick hook
+	bool JoystickHookPresent;
 
 	SharedMemDataJoystick() {
 		JoystickYaw = 0.0f;
 		JoystickPitch = 0.0f;
+		JoystickRoll = 0.0f;
+		GimbalLockFixActive = false;
+		JoystickEmulationEnabled = false;
+		JoystickHookPresent = true;
 	}
 };
 

--- a/xwa_hook_joystick_ff/hook_joystick_ff/joystick.cpp
+++ b/xwa_hook_joystick_ff/hook_joystick_ff/joystick.cpp
@@ -999,11 +999,28 @@ int UpdateControllerHook(int* params)
 			}
 		}
 	}
-	float normYaw = 2.0f * (esp10.dwXpos / 65535.0f - 0.5f); // -1: Left, 1: Right
-	float normPitch = 2.0f * (esp10.dwYpos / 65535.0f - 0.5f); // -1: Up, 1: Down
-	if (g_pSharedData != NULL) {
-		g_pSharedData->JoystickYaw = normYaw;
-		g_pSharedData->JoystickPitch = normPitch;
+
+	if (g_pSharedData != NULL)
+	{
+		g_pSharedData->JoystickHookPresent = true;
+		if (!(g_pSharedData->JoystickEmulationEnabled))
+		{
+			float normYaw   = 2.0f * (esp10.dwXpos / 65535.0f - 0.5f); // -1: Left, 1: Right
+			float normPitch = 2.0f * (esp10.dwYpos / 65535.0f - 0.5f); // -1: Up,   1: Down
+			float normRoll  = 2.0f * (esp10.dwRpos / 65535.0f - 0.5f); // -1: Left, 1: Right
+			g_pSharedData->JoystickYaw   = normYaw;
+			g_pSharedData->JoystickPitch = normPitch;
+			g_pSharedData->JoystickRoll  = normRoll;
+
+			if (g_pSharedData->GimbalLockFixActive)
+			{
+				// Nullify the joystick input. This allows the gimbal lock fix code in ddraw
+				// to do its job.
+				esp10.dwXpos = 32767;
+				esp10.dwYpos = 32767;
+				esp10.dwRpos = 32767;
+			}
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
These are minor changes to SharedMem that are needed to enable the Gimbal Lock fix.

// The joystick roll is now used by the gimbal lock fix code. So this hook needs to publish it:
// Set by this hook
float JoystickRoll;

// If the gimbal lock fix is active, the following will disable the joystick
// (default: false). Set by ddraw
bool GimbalLockFixActive;

// Set by ddraw when joystick emulation is enabled bool JoystickEmulationEnabled;
// Set by the joystick hook
bool JoystickHookPresent;
