### PR TITLE
Add Titlebar Option for window drag

### DIFF
--- a/xwa_hook_windowed/hook_windowed/windowed.cpp
+++ b/xwa_hook_windowed/hook_windowed/windowed.cpp
@@ -35,6 +35,7 @@ public:
 		int y = GetFileKeyValueInt(lines, "Y");
 		int width = GetFileKeyValueInt(lines, "Width");
 		int height = GetFileKeyValueInt(lines, "Height");
+		bool titlebar = GetFileKeyValueInt(lines, "TitleBar");
 
 		if (x < 0)
 		{
@@ -102,6 +103,7 @@ public:
 		this->Y = y;
 		this->Width = width;
 		this->Height = height;
+		this->Titlebar = titlebar;
 
 		this->ShowSplashScreen = GetFileKeyValueInt(lines, "ShowSplashScreen", 0) != 0;
 	}
@@ -112,6 +114,7 @@ public:
 	int Width;
 	int Height;
 	bool ShowSplashScreen;
+	bool Titlebar;
 };
 
 WindowConfig g_windowConfig;
@@ -353,11 +356,27 @@ int CreateWindowHook(int* params)
 	ATOM atom = (ATOM)params[0];
 	HINSTANCE hInstance = (HINSTANCE)params[1];
 
+	DWORD windowStyle = WS_POPUP | WS_VISIBLE;
+
+	if (!g_windowConfig.IsFullscreen)
+	{
+		windowStyle |= WS_BORDER;
+		
+		if (g_windowConfig.Titlebar)
+		{
+			windowStyle |= WS_CAPTION;
+			windowStyle |= WS_SYSMENU;
+			windowStyle |= WS_MINIMIZEBOX;
+			windowStyle |= WS_MAXIMIZEBOX;
+			g_windowConfig.Height += 25;  // Add titlebar height to window height to maintain size.
+		}
+	}
+
 	HWND hwnd = CreateWindowExA(
 		0,
 		(LPCSTR)atom,
 		"X-Wing Alliance",
-		WS_POPUP | WS_VISIBLE,
+		windowStyle,
 		g_windowConfig.X, g_windowConfig.Y,
 		g_windowConfig.Width, g_windowConfig.Height,
 		nullptr,


### PR DESCRIPTION
Allows an option in the hook_windowed.cfg file for adding a titlebar to the window style.  This allows the user to drag the window, minimize, maximize and restore.  It is finicky however and some more work may need to be done for lost or gain focus events to deal with the mouse hook functionality integration.