### PR TITLE
hook_windowed: Removed window border when Titlebar disabled

### DIFF
--- a/xwa_hook_windowed/hook_windowed/windowed.cpp
+++ b/xwa_hook_windowed/hook_windowed/windowed.cpp
@@ -358,18 +358,14 @@ int CreateWindowHook(int* params)
 
 	DWORD windowStyle = WS_POPUP | WS_VISIBLE;
 
-	if (!g_windowConfig.IsFullscreen)
+	if (!g_windowConfig.IsFullscreen && g_windowConfig.Titlebar)
 	{
 		windowStyle |= WS_BORDER;
-
-		if (g_windowConfig.Titlebar)
-		{
-			windowStyle |= WS_CAPTION;
-			windowStyle |= WS_SYSMENU;
-			windowStyle |= WS_MINIMIZEBOX;
-			windowStyle |= WS_MAXIMIZEBOX;
-			g_windowConfig.Height += 25;  // Add titlebar height to window height to maintain size.
-		}
+		windowStyle |= WS_CAPTION;
+		windowStyle |= WS_SYSMENU;
+		windowStyle |= WS_MINIMIZEBOX;
+		windowStyle |= WS_MAXIMIZEBOX;
+		g_windowConfig.Height += 25;  // Add titlebar height to window height to maintain size.
 	}
 
 	HWND hwnd = CreateWindowExA(


### PR DESCRIPTION
When using a window that spans over multiple monitors (for example for a triple screen), this border makes the window stay behind the taskbar. Without the border, the taskbar is hidden by the window as it should be.

If there is no specific reason to keep the border, I think it would be better to disable by default.
If it is needed, it can be put behind a parameter or disabled selectively when the window size is bigger than the current monitor, not just exactly equal